### PR TITLE
Fix MihoyoRestClientTests

### DIFF
--- a/src/main/java/com/uf/genshinwishes/service/mihoyo/MihoyoRestClient.java
+++ b/src/main/java/com/uf/genshinwishes/service/mihoyo/MihoyoRestClient.java
@@ -8,7 +8,6 @@ import com.uf.genshinwishes.model.BannerType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;


### PR DESCRIPTION
- Most importantly, tests seem to pass now which is better than them
  being broken. May also make sense to delete them
- Remove unnecessary arg validation when mocking (I believe Mockito
  maintainers themselves recommend against this)
- Remove verify too... what's the point of verifying that some hardcoded
  string is passed in when you hardcode it against in the test?